### PR TITLE
check plain password text.

### DIFF
--- a/alVatross/views/login.py
+++ b/alVatross/views/login.py
@@ -23,6 +23,11 @@ def index(request):
             login(request, user)
             return redirect('/alVatross/')
 
+        # [MEMO]: 脆弱性。ハッシュされていないパスワードでもチェックしてログインさせる。
+        if password == user.password:
+            login(request, user)
+            return redirect('/alVatross/')
+
         error_message = "パスワードが間違っています。"
         params['error'] = [error_message]
         return render(request, 'alVatross/login.html', params)


### PR DESCRIPTION
check plain password text.

alVatrossの画面からユーザを作成した場合、ログインができなかった。
理由としてはログイン時にDjangoデフォルトの`check_password()`を使って、自動的にハッシュ値で計算をしてくれていたため。
`check_password()`で`False`の後に、平文でもチェックするように修正。