### PR TITLE
change X-FRAME-OPTIONS settins.

### DIFF
--- a/alVatross/settings.py
+++ b/alVatross/settings.py
@@ -50,6 +50,12 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+# X-Frame-Options
+X_FRAME_OPTIONS = "allow"
+
+# Security Settings.
+XS_SHARING_ALLOWED_METHODS = ['POST','GET','OPTIONS', 'PUT', 'DELETE']
+
 ROOT_URLCONF = 'alVatross.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
```
HTTP/1.1 200 OK
Date: Sun, 28 Apr 2024 00:36:56 GMT
Server: WSGIServer/0.2 CPython/3.7.8
Content-Type: text/html; charset=utf-8
X-Frame-Options: ALLOW
Vary: Cookie
Content-Length: 20814
Set-Cookie:  csrftoken=gtJRSbGnG0lZr1HQERdg3NXRcb0tm9ZJV4TDH3cVW3uKj3p3U1yoDHQmy92wdox5; expires=Sun, 27-Apr-2025 00:36:56 GMT; Max-Age=31449600; Path=/

```